### PR TITLE
ci: add Bandit + CodeQL security scan, fix real findings it surfaced

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,37 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  bandit:
+    name: Bandit SAST
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Bandit
+        run: pip install bandit
+      - name: Run Bandit
+        run: bandit -r . -x ./tests -ll
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3

--- a/spr888.py
+++ b/spr888.py
@@ -177,7 +177,7 @@ def is_private_ioc(ioc: str) -> bool:
     ioc = ioc.strip().lower()
     
     # Check for localhost domains
-    if ioc in ["localhost", "127.0.0.1", "::1", "0.0.0.0"]:
+    if ioc in ["localhost", "127.0.0.1", "::1", "0.0.0.0"]:  # nosec B104 -- string comparison, not a socket bind
         return True
         
     # Check for .local domains
@@ -268,7 +268,7 @@ def query_threatfox(ioc_type: str, ioc_value: str) -> str:
     data = {"query": "search_ioc", "search_term": ioc_value, "exact_match": False}
 
     try:
-        response = requests.post(url, headers=headers, json=data)
+        response = requests.post(url, headers=headers, json=data, timeout=10)
         result = response.json()
 
         if result.get("query_status") == "ok" and result.get("data"):
@@ -324,7 +324,7 @@ def query_virustotal(ioc_type: str, ioc_value: str) -> str:
 
     headers = {"accept": "application/json", "x-apikey": vt_api_key}
     try:
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=10)
         if response.status_code != 200:
             return f"Error {response.status_code}: {response.text}"
 


### PR DESCRIPTION
Adds Bandit + CodeQL CI. Bandit's 3 Medium findings: one was a false positive (a plain string comparison against the literal '0.0.0.0', not a socket bind) -- annotated; the other two were requests calls with no timeout -- fixed. Verified locally: 0 medium/high remaining.